### PR TITLE
fixed time tests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E203
+max-line-length = 88

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-ignore = E203
+ignore = E203, W503
 max-line-length = 88

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ credentials.yaml
 config.yaml
 todo.md
 .vscode/*
+resources/minecraft/*

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,2 @@
+[isort]
+profile=black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 repos:
+-   repo: https://github.com/pycqa/isort
+    rev: 5.8.0
+    hooks:
+    - id: isort
+      name: isort
 -   repo: https://github.com/ambv/black
     rev: stable
     hooks:

--- a/src/discord_bot/lib/server_menu.py
+++ b/src/discord_bot/lib/server_menu.py
@@ -2,6 +2,7 @@ import os
 from datetime import datetime, timedelta
 
 import croniter
+
 from discord_bot.lib.components import Button, ButtonStyle, ComponentRow
 from discord_bot.lib.response import Embed, EmbedColor, Response
 from discord_bot.lib.server import Server, ServerState
@@ -97,10 +98,11 @@ class ServerMenu:
         now = get_current_time()
         sched = os.environ[environ][1 : 1 - 3]
         sched = sched.replace("?", "*")
-        environ = croniter.croniter(sched, now)
-        next_date = environ.get_next(datetime)
-        cent_time = timedelta(hours=-5)
-        next_date = next_date + cent_time
+        cron = croniter.croniter(sched, now)
+        next_date = cron.get_next(datetime)
+        cent_time_delta = timedelta(hours=-5)
+        next_date = next_date + cent_time_delta
+
         return str(next_date)
 
     def get_response(self):

--- a/src/discord_bot/lib/server_menu.py
+++ b/src/discord_bot/lib/server_menu.py
@@ -1,9 +1,15 @@
-from datetime import datetime, timedelta
-import croniter
 import os
+from datetime import datetime, timedelta
+
+import croniter
 from discord_bot.lib.components import Button, ButtonStyle, ComponentRow
 from discord_bot.lib.response import Embed, EmbedColor, Response
 from discord_bot.lib.server import Server, ServerState
+
+
+# this function is to allow mocking of datetime.now()
+def get_current_time():
+    return datetime.now()
 
 
 class ServerMenu:
@@ -82,21 +88,17 @@ class ServerMenu:
             )
 
     def get_next_start_time(self):
-        now = datetime.now()
-        sched = os.environ["START_SCHEDULE"][1 : 1 - 3]
-        sched = sched.replace("?", "*")
-        cron = croniter.croniter(sched, now)
-        next_date = cron.get_next(datetime)
-        cent_time = timedelta(hours=-5)
-        next_date = next_date + cent_time
-        return str(next_date)
+        return self.get_next_time_from_cron("START_SCHEDULE")
 
     def get_next_stop_time(self):
-        now = datetime.now()
-        sched = os.environ["STOP_SCHEDULE"][1 : 1 - 3]
+        return self.get_next_time_from_cron("STOP_SCHEDULE")
+
+    def get_next_time_from_cron(self, environ):
+        now = get_current_time()
+        sched = os.environ[environ][1 : 1 - 3]
         sched = sched.replace("?", "*")
-        cron = croniter.croniter(sched, now)
-        next_date = cron.get_next(datetime)
+        environ = croniter.croniter(sched, now)
+        next_date = environ.get_next(datetime)
         cent_time = timedelta(hours=-5)
         next_date = next_date + cent_time
         return str(next_date)

--- a/tst/discord_bot/test_menu.py
+++ b/tst/discord_bot/test_menu.py
@@ -1,3 +1,6 @@
+from datetime import datetime
+from unittest.mock import patch
+
 from pytest import mark
 
 from discord_bot.lib.components import Components
@@ -68,7 +71,9 @@ def test_response_is_valid(server_menu_factory):
     assert next(component_iter).custom_id == Components.REFRESH_MENU
 
 
-def test_Schedule_works(server_menu_factory):
+@patch("discord_bot.lib.server_menu.get_current_time")
+def test_schedule_works(dt, server_menu_factory):
+    dt.return_value = datetime(2021, 9, 27, 4, 0, 0)
     server_menu = server_menu_factory()
     response = server_menu.get_next_start_time()
     assert response == "2021-09-27 15:00:00"


### PR DESCRIPTION
always uses same datetime.now time now

also added config for `flake8` in project and made it ignore e203 so it doesn't conflict with `black`, added isort to pre-commits to auto sort imports

and minor cleanup of the get_next_time functions